### PR TITLE
Minor changes.

### DIFF
--- a/pyttyplay.py
+++ b/pyttyplay.py
@@ -228,13 +228,13 @@ class App:
     def copy_buffer(self):
         try:
             # We only autodetect height because it's cheap.
-            self.max_ttyrec_height = max(max(self.screen._buffer.keys()) + 1, self.max_ttyrec_height)
+            self.max_ttyrec_height = max(max(self.screen.buffer.keys()) + 1, self.max_ttyrec_height)
         except:
             pass
         return (
             self.screen.cursor.x,
             self.screen.cursor.y,
-            {y: dict(row) for y, row in self.screen._buffer.items()},
+            {y: dict(row) for y, row in self.screen.buffer.items()},
             self.screen.dirty.copy(),
         )
 

--- a/pyttyplay.py
+++ b/pyttyplay.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import gc
 import sys


### PR DESCRIPTION
Hi Moult,

Just discovered pyttyplay. Great tool.

However, when starting it for the first time in a venv with pyte's latest version, 0.8.2, _buffer wasn't defined.
The API docs just mentioned [buffer](https://pyte.readthedocs.io/en/latest/api.html#pyte.screens.Screen), and adjusting it allowed it to start.

I've also added a shebang and execute bit for ease of running on *unix systems.